### PR TITLE
Release v0.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,21 +3,21 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.5
     hooks:
       - id: codespell
         args: [--ignore-words=.codespellignore]
         types_or: [jupyter, markdown, python, shell]
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+    rev: v1.5.1
     hooks:
       - id: mypy
         additional_dependencies:
@@ -29,6 +29,6 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    rev: v0.35.0
     hooks:
       - id: markdownlint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ number as needed.
 
 ## [Unreleased]
 
+## [0.1.0] - 2023-08-31
+
 ### Changed
 
 - `read_dimensions_and_variables` allows small differences in step size to be
@@ -19,5 +21,6 @@ number as needed.
 
 Initial release
 
-[Unreleased]: <https://github.com/stactools-packages/datacube/compare/v0.0.1..main>
+[Unreleased]: <https://github.com/stactools-packages/datacube/compare/v0.1.0..main>
+[0.1.0]: <https://github.com/stactools-packages/datacube/compare/v0.0.1..v0.1.0>
 [0.0.1]: <https://github.com/stactools-packages/datacube/tree/v0.0.1/>

--- a/src/stactools/datacube/__init__.py
+++ b/src/stactools/datacube/__init__.py
@@ -14,4 +14,4 @@ def register_plugin(registry: Registry) -> None:
     registry.register_subcommand(commands.create_datacube_command)
 
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"


### PR DESCRIPTION
I decided to go for a v0.1.0 since it seems like this **stactools-package** is being used by downstreams, and a v0.1.0 is a sign of that maturity.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] Examples have been updated to reflect changes, if applicable
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
